### PR TITLE
Exclude Tika dependency on cxf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>se.repos</groupId>
 		<artifactId>maven-parent</artifactId>
-		<version>2.6</version>
+		<version>2.7</version>
 		<relativePath/>
 	</parent>
 	
@@ -44,6 +44,12 @@
 			<groupId>org.apache.tika</groupId>
 			<artifactId>tika-parsers</artifactId>
 			<version>1.14</version>
+			<exclusions>
+                <exclusion>
+                    <groupId>org.apache.cxf</groupId>
+                    <artifactId>cxf-rt-rs-client</artifactId>
+                </exclusion>
+            </exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.tika</groupId>


### PR DESCRIPTION
Exclude Tika dependency on cxf, primarily used for accessing optional web services.

Causes issues when combined with other JAX-RS frameworks, e.g. Jersey.