### PR TITLE
Skip fulltext extraction of empty files.

### DIFF
--- a/src/main/java/se/repos/indexing/fulltext/HandlerFulltext.java
+++ b/src/main/java/se/repos/indexing/fulltext/HandlerFulltext.java
@@ -58,6 +58,11 @@ public class HandlerFulltext implements IndexingItemHandler {
 			return;
 		}
 
+		if (item.getFilesize() == 0) {
+			logger.trace("Skipping empty file {}", item);
+			return;
+		}
+
 		// Indexing both traditional Metadata and XMPMetadata (tika-xmp).
 		// TODO pre-load metadata with for example explicit content type from svn prop
 		Metadata metadata = new Metadata();

--- a/src/test/java/se/repos/indexing/fulltext/ItemFulltextExtractionTest.java
+++ b/src/test/java/se/repos/indexing/fulltext/ItemFulltextExtractionTest.java
@@ -24,6 +24,20 @@ public class ItemFulltextExtractionTest {
 	}
 
 	@Test
+	public void testEmpty1() {
+		HandlerFulltext fulltext = new HandlerFulltext();
+		
+		IndexingItemProgress item = new IndexingItemStandalone("repos-search-v1/docs/empty.txt");
+		fulltext.handle(item);
+		IndexingDoc fields = item.getFields();
+		
+		assertFalse("Should not flag as error, Tika 1.23 throws specific exception", fields.containsKey("text_error"));
+		// Tika 1.23: org.apache.tika.exception.ZeroByteFileException
+		assertFalse("Text extraction suppressed when empty", fields.containsKey("text"));
+	}
+	
+	
+	@Test
 	public void testExcel1() {
 		HandlerFulltext fulltext = new HandlerFulltext();
 


### PR DESCRIPTION
Tika 1.23 throws exception.